### PR TITLE
break: return ValidationResult object when verifying SBOMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 coverage/
 coverage.out
 sbom-validator.*.cdx.json
+vendor/

--- a/README.md
+++ b/README.md
@@ -60,24 +60,25 @@ func main() {
         log.Fatalf("Failed to read SBOM file: %v", err)
     }
 
-    isValid, validationErrors, err := sbomvalidator.ValidateSBOMData(jsonData)
-    if err != nil {
-        log.Fatalf("Error during validation - %v", err)
-    }
+    result, err := sbomvalidator.ValidateSBOMData(jsonData)
+	if err != nil {
+		log.Fatalf("Error during validation - %v", err)
+	}
 
-    if isValid {
-        fmt.Println("SBOM is valid")
-    } else {
-        fmt.Printf("Validation failed! Showing up to %d errors:\n", 10)
+    if result.IsValid {
+		output, _ := json.MarshalIndent(result, "", " ")
+		fmt.Println(string(output))
+	} else {
+		fmt.Printf("Validation failed! Showing up to %d errors:\n", 10)
 
-        for i, errMsg := range validationErrors {
-            if i >= 10 {
-                fmt.Printf("...and %d more errors.\n", len(validationErrors)-10)
-                break
-            }
-            fmt.Printf("- %s\n", errMsg)
-        }
-    }
+		for i, errMsg := range result.ValidationErrors {
+			if i >= 10 {
+				fmt.Printf("...and %d more errors.\n", len(result.ValidationErrors)-10)
+				break
+			}
+			fmt.Printf("- %s\n", errMsg)
+		}
+	}
 }
 ```
 
@@ -103,7 +104,12 @@ make build
 ./bin/sbom-validator-example -file sample-sboms/sample-1.6.cdx.json
 CycloneDX SBOM type detected
 CycloneDX version is set to: 1.6
-SBOM is valid
+{
+ "isValid": true,
+ "sbomType": "CycloneDX",
+ "sbomVersion": "1.6",
+ "detectedFormat": "JSON"
+}
 ```
 
 ## License

--- a/example/main.go
+++ b/example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -45,19 +46,20 @@ func main() {
 		log.Fatalf("Failed to read SBOM file: %v", err)
 	}
 
-	isValid, validationErrors, err := sbomvalidator.ValidateSBOMData(jsonData)
+	result, err := sbomvalidator.ValidateSBOMData(jsonData)
 	if err != nil {
 		log.Fatalf("Error during validation - %v", err)
 	}
 
-	if isValid {
-		fmt.Println("SBOM is valid")
+	if result.IsValid {
+		output, _ := json.MarshalIndent(result, "", " ")
+		fmt.Println(string(output))
 	} else {
 		fmt.Printf("Validation failed! Showing up to %d errors:\n", 10)
 
-		for i, errMsg := range validationErrors {
+		for i, errMsg := range result.ValidationErrors {
 			if i >= 10 {
-				fmt.Printf("...and %d more errors.\n", len(validationErrors)-10)
+				fmt.Printf("...and %d more errors.\n", len(result.ValidationErrors)-10)
 				break
 			}
 			fmt.Printf("- %s\n", errMsg)

--- a/validator.go
+++ b/validator.go
@@ -15,6 +15,15 @@ const (
 	SBOM_SPDX      = "SPDX"
 )
 
+type ValidationResult struct {
+	IsValid          bool     `json:"isValid"`
+	SBOMType         string   `json:"sbomType,omitempty"`
+	SBOMVersion      string   `json:"sbomVersion,omitempty"`
+	ValidationErrors []string `json:"validationErrors,omitempty"`
+	SchemaUsed       string   `json:"schemaUsed,omitempty"`
+	DetectedFormat   string   `json:"detectedFormat,omitempty"`
+}
+
 // Embed all JSON schema files from the schemas/cyclonedx directory
 //
 //go:embed schemas/cyclonedx/*.json schemas/spdx/*.json
@@ -61,27 +70,49 @@ var schemaFS embed.FS
 //	} else {
 //	    fmt.Println("SBOM validation errors:", errors)
 //	}
-func ValidateSBOMData(sbomContent []byte) (bool, []string, error) {
+func ValidateSBOMData(sbomContent []byte) (*ValidationResult, error) {
+	result := &ValidationResult{}
+
 	if isJSON(sbomContent) {
+		result.DetectedFormat = "JSON"
+
 		sbomType, err := detectSBOMType(string(sbomContent))
 		if err != nil {
-			return false, nil, fmt.Errorf("error detecting SBOM Type %s", err.Error())
+			return result, fmt.Errorf("error detecting SBOM Type %v", err)
 		}
+		result.SBOMType = sbomType
 
 		sbomSchemaVersion, err := extractSBOMVersion(string(sbomContent), sbomType)
 		if err != nil {
-			return false, nil, fmt.Errorf("failed to extract version: %v", err)
+			return result, fmt.Errorf("failed to extract SBOM version: %v", err)
 		}
+		result.SBOMVersion = sbomSchemaVersion
 
 		schema, err := loadSBOMSchema(sbomSchemaVersion, sbomType)
 		if err != nil {
-			return false, nil, fmt.Errorf("failed to load schema: %v", err)
+			return result, fmt.Errorf("failed to load schema: %v", err)
 		}
 
-		return validateSBOM(schema, string(sbomContent))
+		isValid, validationErrors, err := validateSBOM(schema, string(sbomContent))
+		if err != nil {
+			return result, fmt.Errorf("validation error: %v", err)
+		}
+
+		result.IsValid = isValid
+		result.ValidationErrors = validationErrors
+
+		// for SPDX SBOMs split the type and version (ie: SPDX-2.3)
+		if strings.HasPrefix(sbomType, SBOM_SPDX) {
+			result.SBOMType = SBOM_SPDX
+			result.SBOMVersion, _ = getSPDXVersion(sbomType)
+		}
+
+		return result, nil
 
 	} else {
-		return false, nil, fmt.Errorf("unsupported file format")
+		result.IsValid = false
+		result.DetectedFormat = "non-JSON"
+		return result, fmt.Errorf("unsupported file format")
 	}
 }
 

--- a/validator.go
+++ b/validator.go
@@ -15,6 +15,18 @@ const (
 	SBOM_SPDX      = "SPDX"
 )
 
+// ValidationResult represents the outcome of validating a Software Bill of Materials (SBOM).
+//
+// It provides detailed information about the validation process, including:
+//   - Whether the SBOM is valid (`IsValid`).
+//   - The detected SBOM type (e.g., CycloneDX, SPDX).
+//   - The SBOM schema or specification version.
+//   - A list of any validation errors encountered.
+//   - The schema file or source used during validation.
+//   - The detected input format (e.g., JSON, XML, etc.).
+//
+// This struct is returned by `ValidateSBOMData` and can be serialized to JSON
+// for use in CLI tools, APIs, or automated pipelines.
 type ValidationResult struct {
 	IsValid          bool     `json:"isValid"`
 	SBOMType         string   `json:"sbomType,omitempty"`


### PR DESCRIPTION
Returning a full ValidationResult object

```
// ValidationResult represents the outcome of validating a Software Bill of Materials (SBOM).
//
// It provides detailed information about the validation process, including:
//   - Whether the SBOM is valid (`IsValid`).
//   - The detected SBOM type (e.g., CycloneDX, SPDX).
//   - The SBOM schema or specification version.
//   - A list of any validation errors encountered.
//   - The schema file or source used during validation.
//   - The detected input format (e.g., JSON, XML, etc.).
//
// This struct is returned by `ValidateSBOMData` and can be serialized to JSON
// for use in CLI tools, APIs, or automated pipelines.
type ValidationResult struct {
	IsValid          bool     `json:"isValid"`
	SBOMType         string   `json:"sbomType,omitempty"`
	SBOMVersion      string   `json:"sbomVersion,omitempty"`
	ValidationErrors []string `json:"validationErrors,omitempty"`
	SchemaUsed       string   `json:"schemaUsed,omitempty"`
	DetectedFormat   string   `json:"detectedFormat,omitempty"`
}

```

Previously only a bool was being returned