### PR TITLE
Add AI-SBOM 1.0.0 validation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,29 @@
 **sbom-validator** is a Go library designed to validate
 **Software Bill of Materials (SBOMs)** against the official
 SBOM specifications. It ensures compliance with formats like
-**CycloneDX** & **SPDX** and helps maintain software supply chain security.
+**CycloneDX**, **SPDX**, and **AI-SBOM** and helps maintain software supply chain security.
 
 ## Features
 
-✅ Detects SBOM type (e.g., CycloneDX, SPDX)
+✅ Detects SBOM type (e.g., CycloneDX, SPDX, AI-SBOM)
 
 ✅ Extracts SBOM version
 
 ✅ Validates SBOM against official schemas
 
 ✅ Provides detailed validation errors
+
+## Supported Formats
+
+- CycloneDX JSON schemas: 1.2, 1.3, 1.4, 1.5, 1.6, 1.7
+- SPDX JSON schemas: 2.2, 2.3
+- AI-SBOM JSON schema: 1.0.0
+
+The AI-SBOM schema is embedded from the immutable schema URL:
+
+```text
+https://shiftleftcyber.io/ai-bom/schemas/ai-sbom-1.0.0.schema.json
+```
 
 ## Installation
 
@@ -55,6 +67,8 @@ suffix should remain on the `v1` line until they are ready to migrate.
 package main
 
 import (
+    "encoding/json"
+    "flag"
     "fmt"
     "log"
     "os"
@@ -82,24 +96,24 @@ func main() {
     }
 
     result, err := sbomvalidator.ValidateSBOMData(jsonData)
-	if err != nil {
-		log.Fatalf("Error during validation - %v", err)
-	}
+    if err != nil {
+        log.Fatalf("Error during validation - %v", err)
+    }
 
     if result.IsValid {
-		output, _ := json.MarshalIndent(result, "", " ")
-		fmt.Println(string(output))
-	} else {
-		fmt.Printf("Validation failed! Showing up to %d errors:\n", 10)
+        output, _ := json.MarshalIndent(result, "", " ")
+        fmt.Println(string(output))
+    } else {
+        fmt.Printf("Validation failed! Showing up to %d errors:\n", 10)
 
-		for i, errMsg := range result.ValidationErrors {
-			if i >= 10 {
-				fmt.Printf("...and %d more errors.\n", len(result.ValidationErrors)-10)
-				break
-			}
-			fmt.Printf("- %s\n", errMsg)
-		}
-	}
+        for i, errMsg := range result.ValidationErrors {
+            if i >= 10 {
+                fmt.Printf("...and %d more errors.\n", len(result.ValidationErrors)-10)
+                break
+            }
+            fmt.Printf("- %s\n", errMsg)
+        }
+    }
 }
 ```
 
@@ -139,7 +153,23 @@ DEBUG: 2026/04/07 14:00:00 CycloneDX version is set to: 1.6
  "sbomVersion": "1.6",
  "detectedFormat": "JSON"
 }
+
+./bin/sbom-validator-example -file sample-sboms/customer-support-ai-sbom.json
+{
+ "isValid": true,
+ "sbomType": "AI-SBOM",
+ "sbomVersion": "1.0.0",
+ "detectedFormat": "JSON"
+}
 ```
+
+AI-SBOM examples are included under `sample-sboms/`:
+
+- `customer-support-ai-sbom.json`
+- `medical-triage-ai-sbom.json`
+- `missing-required-metadata.json`
+- `bad-types-and-enums-ai-sbom.json`
+- `unknown-extra-properties-ai-sbom.json`
 
 ## License
 

--- a/sample-sboms/bad-types-and-enums-ai-sbom.json
+++ b/sample-sboms/bad-types-and-enums-ai-sbom.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "1.0.0",
+  "metadata": {
+    "bomFormat": "AI-SBOM",
+    "sbomAuthor": "Example Author",
+    "sbomVersion": "1.0.0",
+    "sbomDataFormatName": "AI SBOM JSON",
+    "sbomDataFormatVersion": "1.0.0",
+    "sbomAuthorSignature": {
+      "algorithm": "ecdsa-p256-sha256",
+      "value": "signature"
+    },
+    "sbomToolName": "Example Tool",
+    "sbomToolVersion": "1.0.0",
+    "sbomGenerationContext": "during-lunch",
+    "sbomTimestamp": "not a timestamp",
+    "sbomDependencyRelationships": []
+  },
+  "system": {
+    "systemName": "Example System",
+    "systemComponents": [],
+    "systemProducer": "Example Producer",
+    "systemVersion": 2,
+    "systemTimestamp": "2026-05-18T14:22:31Z",
+    "systemDataFlow": [],
+    "systemDataUsage": "Example usage.",
+    "systemInputOutputProperties": {
+      "inputModalities": [],
+      "outputModalities": [
+        "text"
+      ],
+      "inputPreprocessing": "none"
+    },
+    "intendedApplicationArea": []
+  },
+  "models": [],
+  "datasets": [],
+  "infrastructure": {
+    "infrastructureSoftware": [],
+    "infrastructureHardware": {
+      "hbomUrl": "https://example.com/hbom",
+      "description": "Example HBOM."
+    }
+  },
+  "security": {
+    "securityControls": [],
+    "securityCompliance": [],
+    "cybersecurityPolicyInformation": "https://example.com/security.txt",
+    "vulnerabilityReferencing": []
+  },
+  "kpis": {
+    "securityMetrics": [],
+    "operationalPerformanceKpis": []
+  }
+}

--- a/sample-sboms/customer-support-ai-sbom.json
+++ b/sample-sboms/customer-support-ai-sbom.json
@@ -1,0 +1,286 @@
+{
+  "schemaVersion": "1.0.0",
+  "metadata": {
+    "bomFormat": "AI-SBOM",
+    "sbomAuthor": "Contoso Security Engineering",
+    "sbomVersion": "1.0.0",
+    "sbomDataFormatName": "AI SBOM JSON",
+    "sbomDataFormatVersion": "1.0.0",
+    "sbomAuthorSignature": {
+      "algorithm": "ecdsa-p256-sha256",
+      "value": "MEUCIQDV8xF3h3Tn0Qj1exampleSignatureValue"
+    },
+    "sbomToolName": "Contoso AI Inventory Builder",
+    "sbomToolVersion": "2.4.1",
+    "sbomGenerationContext": "after-build",
+    "sbomTimestamp": "2026-05-18T14:22:31Z",
+    "sbomDependencyRelationships": [
+      {
+        "source": "Contoso Customer Support Assistant",
+        "relationship": "includes",
+        "target": "Atlas Chat Small"
+      }
+    ]
+  },
+  "system": {
+    "systemName": [
+      "Contoso Customer Support Assistant"
+    ],
+    "systemComponents": [
+      {
+        "name": "Atlas Chat Small",
+        "type": "ai-model",
+        "version": "3.2.0",
+        "supplier": "Atlas Model Works"
+      },
+      {
+        "name": "Customer Knowledge Retrieval Service",
+        "type": "service",
+        "version": "1.8.3",
+        "supplier": "Contoso"
+      }
+    ],
+    "systemProducer": "Contoso",
+    "systemVersion": "2026.05.1",
+    "systemTimestamp": "2026-05-17T09:00:00Z",
+    "systemDataFlow": [
+      {
+        "source": "Support chat user interface",
+        "destination": "Customer Knowledge Retrieval Service",
+        "description": "User message and session metadata are sent for retrieval augmented generation.",
+        "protocol": "HTTPS",
+        "externalService": false
+      },
+      {
+        "source": "Customer Knowledge Retrieval Service",
+        "destination": "Atlas Chat Small",
+        "description": "Retrieved support snippets and the user prompt are sent to the model.",
+        "protocol": "HTTPS",
+        "externalService": true
+      }
+    ],
+    "systemDataUsage": "Prompts and retrieved snippets are used for response generation and abuse monitoring. Customer prompts are retained for 30 days and are not used to train model weights.",
+    "systemInputOutputProperties": {
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "inputPreprocessing": "Unicode normalization, profanity filter, prompt-injection classifier, and tokenizer atlas-bpe-v3.",
+      "decisionImpactDocumentationUrl": "https://example.com/contoso/customer-support-assistant/decision-impact"
+    },
+    "intendedApplicationArea": [
+      "customer support",
+      "near real time application"
+    ]
+  },
+  "models": [
+    {
+      "modelName": [
+        "Atlas Chat Small"
+      ],
+      "modelIdentifiers": [
+        {
+          "type": "purl",
+          "value": "pkg:huggingface/atlas-model-works/atlas-chat-small@3.2.0"
+        }
+      ],
+      "modelVersion": "3.2.0",
+      "modelTimestamp": "2026-04-20T12:00:00Z",
+      "modelProducers": [
+        "Atlas Model Works"
+      ],
+      "modelDescription": {
+        "capabilities": "Instruction-following text generation for customer support workflows.",
+        "knownLimitations": "May produce incorrect answers when retrieval context is incomplete.",
+        "lineage": "Fine-tuned from Atlas Base Small 3.0 using support instruction examples.",
+        "dependencies": [
+          "transformers",
+          "sentencepiece"
+        ]
+      },
+      "modelHashValue": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "modelHashAlgorithm": "sha-256",
+      "modelProperties": {
+        "modelFamily": "parametric neural network",
+        "architecture": "decoder only transformer",
+        "parameterCount": 7200000000,
+        "hyperparameters": {
+          "maxTemperature": 0.7,
+          "topP": 0.95
+        }
+      },
+      "modelInputOutputProperties": {
+        "inputModalities": [
+          "text"
+        ],
+        "outputModalities": [
+          "text"
+        ],
+        "contextLength": 32768,
+        "inputPreprocessing": "atlas-bpe-v3 tokenizer with system prompt templating"
+      },
+      "modelTrainingProperties": {
+        "learningType": "supervised fine tuning and direct preference optimization",
+        "trainingStages": [
+          "pre-training",
+          "instruction tuning",
+          "direct preference optimization"
+        ],
+        "documentationUrl": "https://example.com/models/atlas-chat-small/model-card"
+      },
+      "modelLicense": {
+        "name": "Atlas Responsible AI License 1.0",
+        "url": "https://example.com/licenses/atlas-rai-1.0",
+        "openness": {
+          "openWeights": false,
+          "openArchitecture": true,
+          "openData": false,
+          "openTraining": false
+        }
+      },
+      "modelExternalReferences": [
+        {
+          "type": "model-card",
+          "url": "https://example.com/models/atlas-chat-small/model-card",
+          "description": "Model card for Atlas Chat Small."
+        }
+      ]
+    }
+  ],
+  "datasets": [
+    {
+      "datasetName": "Contoso Support Instruction Dataset",
+      "datasetDescription": "Private fine-tuning dataset containing support questions and approved answers.",
+      "datasetContent": {
+        "domain": "customer support",
+        "format": "JSON Lines",
+        "dataModalities": [
+          "text"
+        ]
+      },
+      "datasetIdentifiers": [
+        {
+          "type": "uri",
+          "value": "s3://contoso-ml-datasets/support-instructions/2026-04"
+        }
+      ],
+      "datasetHash": {
+        "algorithm": "sha-256",
+        "value": "a4f0c2d8f3e4b5c697887766554433221100ffeeddccbbaa9988776655443322"
+      },
+      "datasetProvenance": {
+        "origin": "Contoso support knowledge base and curated support tickets.",
+        "collectionMethods": [
+          "internal export",
+          "manual curation"
+        ],
+        "processingSteps": [
+          "PII redaction",
+          "deduplication",
+          "quality review"
+        ],
+        "creator": "Contoso Machine Learning Platform",
+        "syntheticDataMethods": "No synthetic records were included."
+      },
+      "datasetStatisticalProperties": {
+        "records": 185000,
+        "medianPromptTokens": 88,
+        "medianCompletionTokens": 143
+      },
+      "datasetSensitivity": {
+        "containsPersonalData": false,
+        "containsSensitiveData": false,
+        "containsCopyrightProtectedData": true,
+        "containsNationalSecurityData": false,
+        "description": "Contains internal support text and product documentation after PII redaction."
+      },
+      "datasetDependencyRelationships": [
+        {
+          "source": "Contoso Support Instruction Dataset",
+          "relationship": "derived-from",
+          "target": "Contoso Support Knowledge Base"
+        }
+      ],
+      "datasetLicense": {
+        "name": "Contoso Internal Use Only",
+        "url": "https://example.com/contoso/data-licenses/internal-use"
+      }
+    }
+  ],
+  "infrastructure": {
+    "infrastructureSoftware": [
+      {
+        "name": "Kubernetes",
+        "type": "runtime",
+        "version": "1.30.7",
+        "supplier": "Cloud Native Computing Foundation"
+      },
+      {
+        "name": "NVIDIA CUDA",
+        "type": "runtime",
+        "version": "12.4",
+        "supplier": "NVIDIA"
+      }
+    ],
+    "infrastructureHardware": {
+      "hbomUrl": "https://example.com/contoso/hbom/customer-support-assistant",
+      "description": "GPU inference nodes and load balancer appliance inventory."
+    }
+  },
+  "security": {
+    "securityControls": [
+      {
+        "name": "Prompt injection classifier",
+        "category": "ai-specific",
+        "description": "Blocks or routes prompts classified as prompt injection attempts.",
+        "referenceUrl": "https://example.com/contoso/security/prompt-injection-controls"
+      },
+      {
+        "name": "API authentication",
+        "category": "general-cybersecurity",
+        "description": "All model invocation APIs require OAuth 2.0 client credentials."
+      }
+    ],
+    "securityCompliance": [
+      {
+        "name": "ISO/IEC 27001",
+        "status": "certified",
+        "referenceUrl": "https://example.com/contoso/certifications/iso-27001"
+      }
+    ],
+    "cybersecurityPolicyInformation": "https://example.com/.well-known/security.txt",
+    "vulnerabilityReferencing": [
+      {
+        "type": "security-advisories",
+        "url": "https://example.com/contoso/security/advisories",
+        "description": "Security advisories for Contoso AI systems."
+      }
+    ]
+  },
+  "kpis": {
+    "securityMetrics": [
+      {
+        "name": "prompt injection block precision",
+        "value": 0.94,
+        "unit": "ratio",
+        "measurementTimestamp": "2026-05-15T00:00:00Z"
+      }
+    ],
+    "operationalPerformanceKpis": [
+      {
+        "name": "p95 latency",
+        "value": 850,
+        "unit": "milliseconds",
+        "measurementTimestamp": "2026-05-15T00:00:00Z"
+      },
+      {
+        "name": "monthly uptime",
+        "value": 99.95,
+        "unit": "percent",
+        "measurementTimestamp": "2026-05-15T00:00:00Z"
+      }
+    ]
+  }
+}

--- a/sample-sboms/medical-triage-ai-sbom.json
+++ b/sample-sboms/medical-triage-ai-sbom.json
@@ -1,0 +1,277 @@
+{
+  "schemaVersion": "1.0.0",
+  "metadata": {
+    "bomFormat": "AI-SBOM",
+    "sbomAuthor": "Northwind Health Security Office",
+    "sbomVersion": "1.1.0",
+    "sbomDataFormatName": "AI SBOM JSON",
+    "sbomDataFormatVersion": "1.0.0",
+    "sbomToolName": "Northwind Supply Chain Ledger",
+    "sbomToolVersion": "unknown",
+    "sbomGenerationContext": "runtime-analysis",
+    "sbomTimestamp": "2026-05-16T18:40:00Z",
+    "sbomDependencyRelationships": [
+      {
+        "source": "Northwind Triage Recommender",
+        "relationship": "includes",
+        "target": "Vitality Classifier"
+      }
+    ]
+  },
+  "system": {
+    "systemName": [
+      "Northwind Triage Recommender",
+      "NTR"
+    ],
+    "systemComponents": [
+      {
+        "name": "Vitality Classifier",
+        "type": "ai-model",
+        "version": "5.0.2",
+        "supplier": "Northwind Health"
+      },
+      {
+        "name": "Clinical Rules Gateway",
+        "type": "software",
+        "version": "4.9.0",
+        "supplier": "Northwind Health"
+      }
+    ],
+    "systemProducer": "Northwind Health",
+    "systemVersion": "5.0.2",
+    "systemTimestamp": "2026-05-10T13:12:00Z",
+    "systemDataFlow": [
+      {
+        "source": "Intake application",
+        "destination": "Clinical Rules Gateway",
+        "description": "Structured intake fields and vital signs are validated against clinical rules.",
+        "protocol": "HTTPS",
+        "externalService": false
+      },
+      {
+        "source": "Clinical Rules Gateway",
+        "destination": "Vitality Classifier",
+        "description": "Validated feature vector is sent for triage risk classification.",
+        "protocol": "gRPC",
+        "externalService": false
+      }
+    ],
+    "systemDataUsage": "Input data is used for triage recommendation and audit logging. Data is not used for online learning.",
+    "systemInputOutputProperties": {
+      "inputModalities": [
+        "structured clinical text",
+        "numeric vital signs"
+      ],
+      "outputModalities": [
+        "classification score",
+        "explanation text"
+      ],
+      "inputPreprocessing": "Schema validation, outlier detection, and feature normalization.",
+      "decisionImpactDocumentationUrl": "https://example.org/northwind/triage/clinical-safety"
+    },
+    "intendedApplicationArea": [
+      "medical healthcare",
+      "clinical triage"
+    ]
+  },
+  "models": [
+    {
+      "modelName": [
+        "Vitality Classifier"
+      ],
+      "modelIdentifiers": [
+        {
+          "type": "uuid",
+          "value": "018f0a7b-ff38-7a3d-9c4f-0b4caed8b212"
+        },
+        {
+          "type": "custom",
+          "value": "northwind:model:vitality-classifier:5.0.2"
+        }
+      ],
+      "modelVersion": "5.0.2",
+      "modelTimestamp": "2026-05-01T08:00:00Z",
+      "modelProducers": [
+        "Northwind Health"
+      ],
+      "modelDescription": {
+        "capabilities": "Classifies patient intake records into triage risk bands.",
+        "knownLimitations": "Not intended for pediatric emergency use or autonomous diagnosis.",
+        "lineage": "Trained from Vitality Classifier 4.8 with new validation cohort calibration.",
+        "dependencies": [
+          "xgboost",
+          "numpy"
+        ]
+      },
+      "modelHashValue": "b1946ac92492d2347c6235b4d2611184b1946ac92492d2347c6235b4d2611184",
+      "modelHashAlgorithm": "sha-256",
+      "modelProperties": {
+        "modelFamily": "non-parametric gradient boosted decision trees",
+        "architecture": "XGBoost ensemble",
+        "parameterCount": "unknown",
+        "hyperparameters": {
+          "maxDepth": 6,
+          "estimators": 500
+        }
+      },
+      "modelInputOutputProperties": {
+        "inputModalities": [
+          "numeric",
+          "categorical",
+          "text-derived features"
+        ],
+        "outputModalities": [
+          "risk score",
+          "risk band"
+        ],
+        "contextLength": "unknown",
+        "inputPreprocessing": "Feature scaling, missing-value imputation, and ICD code normalization."
+      },
+      "modelTrainingProperties": {
+        "learningType": "supervised learning",
+        "trainingStages": [
+          "training",
+          "calibration",
+          "clinical validation"
+        ],
+        "documentationUrl": "https://example.org/northwind/models/vitality-classifier/model-card"
+      },
+      "modelLicense": {
+        "name": "Northwind Proprietary Model License",
+        "url": "https://example.org/northwind/licenses/model-license",
+        "openness": {
+          "openWeights": false,
+          "openArchitecture": false,
+          "openData": false,
+          "openTraining": false
+        }
+      },
+      "modelExternalReferences": [
+        {
+          "type": "validation-report",
+          "url": "https://example.org/northwind/models/vitality-classifier/validation"
+        }
+      ]
+    }
+  ],
+  "datasets": [
+    {
+      "datasetName": "Northwind Deidentified Triage Cohort",
+      "datasetDescription": "Deidentified clinical records used for model training, calibration, and evaluation.",
+      "datasetContent": {
+        "domain": "medical records",
+        "format": "Parquet",
+        "dataModalities": [
+          "structured text",
+          "numeric"
+        ]
+      },
+      "datasetIdentifiers": [
+        {
+          "type": "uri",
+          "value": "https://example.org/northwind/datasets/triage-cohort/2026-01"
+        }
+      ],
+      "datasetHash": {
+        "algorithm": "sha-384",
+        "value": "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7d4c3b2a190e1f3a6eb0790f39ac87c9"
+      },
+      "datasetProvenance": {
+        "origin": "Northwind partner clinics with data use agreements.",
+        "collectionMethods": [
+          "clinical data warehouse export"
+        ],
+        "processingSteps": [
+          "deidentification",
+          "label review",
+          "train validation test split"
+        ],
+        "creator": "Northwind Health Analytics",
+        "syntheticDataMethods": "Synthetic minority oversampling was used only within training folds."
+      },
+      "datasetStatisticalProperties": {
+        "records": 2400000,
+        "positiveClassRate": 0.061,
+        "medianAge": 54
+      },
+      "datasetSensitivity": {
+        "containsPersonalData": false,
+        "containsSensitiveData": true,
+        "containsCopyrightProtectedData": false,
+        "containsNationalSecurityData": false,
+        "description": "Contains deidentified healthcare records with residual clinical sensitivity."
+      },
+      "datasetDependencyRelationships": [],
+      "datasetLicense": {
+        "name": "Restricted Clinical Data Use Agreement",
+        "url": "https://example.org/northwind/data-use/triage-cohort"
+      }
+    }
+  ],
+  "infrastructure": {
+    "infrastructureSoftware": [
+      {
+        "name": "Python",
+        "type": "runtime",
+        "version": "3.12.3",
+        "supplier": "Python Software Foundation"
+      },
+      {
+        "name": "XGBoost",
+        "type": "library",
+        "version": "2.1.0",
+        "supplier": "XGBoost Project"
+      }
+    ],
+    "infrastructureHardware": {
+      "hbomUrl": "https://example.org/northwind/hbom/triage-recommender",
+      "description": "CPU inference cluster and secure enclave configuration."
+    }
+  },
+  "security": {
+    "securityControls": [
+      {
+        "name": "Role-based access control",
+        "category": "general-cybersecurity",
+        "description": "Clinical users must have a triage role assignment to invoke the system."
+      },
+      {
+        "name": "Input anomaly detection",
+        "category": "ai-specific",
+        "description": "Out-of-distribution feature vectors are flagged for manual review."
+      }
+    ],
+    "securityCompliance": [
+      {
+        "name": "HIPAA security risk assessment",
+        "status": "self-attested",
+        "referenceUrl": "https://example.org/northwind/compliance/hipaa-risk-assessment"
+      }
+    ],
+    "cybersecurityPolicyInformation": "https://example.org/.well-known/security.txt",
+    "vulnerabilityReferencing": [
+      {
+        "type": "model-vulnerability-repository",
+        "url": "https://example.org/northwind/security/vitality-classifier"
+      }
+    ]
+  },
+  "kpis": {
+    "securityMetrics": [
+      {
+        "name": "out-of-distribution detection recall",
+        "value": 0.91,
+        "unit": "ratio",
+        "measurementTimestamp": "2026-05-10T00:00:00Z"
+      }
+    ],
+    "operationalPerformanceKpis": [
+      {
+        "name": "incident resolution time",
+        "value": 4.5,
+        "unit": "hours",
+        "measurementTimestamp": "2026-05-10T00:00:00Z"
+      }
+    ]
+  }
+}

--- a/sample-sboms/missing-required-metadata.json
+++ b/sample-sboms/missing-required-metadata.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.0.0",
+  "metadata": {
+    "sbomAuthor": "Example Author",
+    "sbomVersion": "1.0.0",
+    "sbomDataFormatName": "AI SBOM JSON",
+    "sbomDataFormatVersion": "1.0.0",
+    "sbomToolName": "Example Tool",
+    "sbomToolVersion": "1.0.0",
+    "sbomGenerationContext": "after-build",
+    "sbomDependencyRelationships": []
+  },
+  "system": {},
+  "models": [],
+  "datasets": [],
+  "infrastructure": {},
+  "security": {},
+  "kpis": {}
+}

--- a/sample-sboms/unknown-extra-properties-ai-sbom.json
+++ b/sample-sboms/unknown-extra-properties-ai-sbom.json
@@ -1,0 +1,137 @@
+{
+  "schemaVersion": "1.0.0",
+  "metadata": {
+    "bomFormat": "AI-SBOM",
+    "sbomAuthor": "Example Author",
+    "sbomVersion": "1.0.0",
+    "sbomDataFormatName": "AI SBOM JSON",
+    "sbomDataFormatVersion": "1.0.0",
+    "sbomAuthorSignature": {
+      "algorithm": "ecdsa-p256-sha256",
+      "value": "signature"
+    },
+    "sbomToolName": "Example Tool",
+    "sbomToolVersion": "1.0.0",
+    "sbomGenerationContext": "manual",
+    "sbomTimestamp": "2026-05-18T14:22:31Z",
+    "sbomDependencyRelationships": [],
+    "unapprovedField": "This field is not allowed."
+  },
+  "system": {
+    "systemName": [
+      "Example System"
+    ],
+    "systemComponents": [
+      {
+        "name": "Example Model",
+        "type": "ai-model",
+        "version": "1.0.0"
+      }
+    ],
+    "systemProducer": "Example Producer",
+    "systemVersion": "1.0.0",
+    "systemTimestamp": "2026-05-18T14:22:31Z",
+    "systemDataFlow": [
+      {
+        "source": "user",
+        "destination": "model",
+        "description": "Prompt flow."
+      }
+    ],
+    "systemDataUsage": "Prompt processing.",
+    "systemInputOutputProperties": {
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "inputPreprocessing": "Tokenizer."
+    },
+    "intendedApplicationArea": [
+      "example"
+    ]
+  },
+  "models": [
+    {
+      "modelName": [
+        "Example Model"
+      ],
+      "modelIdentifiers": [
+        {
+          "type": "custom",
+          "value": "example-model"
+        }
+      ],
+      "modelVersion": "1.0.0",
+      "modelTimestamp": "2026-05-18T14:22:31Z",
+      "modelProducers": [
+        "Example Producer"
+      ],
+      "modelDescription": {
+        "capabilities": "Example generation.",
+        "knownLimitations": "Example limitation.",
+        "lineage": "Example lineage.",
+        "dependencies": []
+      },
+      "modelHashValue": "not-a-valid-hash",
+      "modelHashAlgorithm": "md5",
+      "modelProperties": {
+        "modelFamily": "neural network",
+        "architecture": "transformer",
+        "parameterCount": 10,
+        "hyperparameters": {}
+      },
+      "modelInputOutputProperties": {
+        "inputModalities": [
+          "text"
+        ],
+        "outputModalities": [
+          "text"
+        ],
+        "contextLength": 1024,
+        "inputPreprocessing": "Tokenizer."
+      },
+      "modelTrainingProperties": {
+        "learningType": "supervised",
+        "trainingStages": [],
+        "documentationUrl": "https://example.com/model-card"
+      },
+      "modelLicense": {
+        "name": "Example License",
+        "url": "https://example.com/license",
+        "openness": {
+          "openWeights": true,
+          "openArchitecture": true,
+          "openData": false,
+          "openTraining": false
+        }
+      },
+      "modelExternalReferences": []
+    }
+  ],
+  "datasets": [],
+  "infrastructure": {
+    "infrastructureSoftware": [],
+    "infrastructureHardware": {
+      "hbomUrl": "https://example.com/hbom",
+      "description": "Example HBOM."
+    }
+  },
+  "security": {
+    "securityControls": [
+      {
+        "name": "API authentication",
+        "category": "general-cybersecurity",
+        "description": "Authenticated API."
+      }
+    ],
+    "securityCompliance": [],
+    "cybersecurityPolicyInformation": "https://example.com/security.txt",
+    "vulnerabilityReferencing": []
+  },
+  "kpis": {
+    "securityMetrics": [],
+    "operationalPerformanceKpis": []
+  }
+}

--- a/schemas/ai-bom/ai-sbom-1.0.0.schema.json
+++ b/schemas/ai-bom/ai-sbom-1.0.0.schema.json
@@ -1,0 +1,922 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shiftleftcyber.io/ai-bom/schemas/ai-sbom-1.0.0.schema.json",
+  "title": "AI Software Bill of Materials",
+  "description": "An AI SBOM schema derived from the G7 SBOM for AI minimum elements document. It captures metadata, system properties, model properties, dataset properties, infrastructure, security properties, and KPIs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "metadata",
+    "system",
+    "models"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    },
+    "system": {
+      "$ref": "#/$defs/system"
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/model"
+      }
+    },
+    "datasets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/dataset"
+      }
+    },
+    "infrastructure": {
+      "$ref": "#/$defs/infrastructure"
+    },
+    "security": {
+      "$ref": "#/$defs/security"
+    },
+    "kpis": {
+      "$ref": "#/$defs/kpis"
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "unknownableString": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Use the literal string 'unknown' when the information is unavailable."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "uri": {
+      "type": "string",
+      "format": "uri"
+    },
+    "hashAlgorithm": {
+      "type": "string",
+      "enum": [
+        "sha-256",
+        "sha-384",
+        "sha-512",
+        "sha3-256",
+        "sha3-384",
+        "sha3-512",
+        "unknown"
+      ]
+    },
+    "hashValue": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "unknown"
+        },
+        {
+          "pattern": "^[A-Fa-f0-9]{64,128}$"
+        }
+      ]
+    },
+    "identifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "cpe",
+            "purl",
+            "uuid",
+            "commit",
+            "omnibor",
+            "swhid",
+            "uri",
+            "custom"
+          ]
+        },
+        "value": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "externalReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "url"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "url": {
+          "$ref": "#/$defs/uri"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "dependencyRelationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "relationship",
+        "target"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "relationship": {
+          "type": "string",
+          "enum": [
+            "includes",
+            "included-in",
+            "depends-on",
+            "derived-from",
+            "descendant-of",
+            "generates",
+            "uses"
+          ]
+        },
+        "target": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bomFormat",
+        "sbomAuthor",
+        "sbomVersion",
+        "sbomDataFormatName",
+        "sbomDataFormatVersion",
+        "sbomTimestamp"
+      ],
+      "properties": {
+        "bomFormat": {
+          "type": "string",
+          "const": "AI-SBOM",
+          "description": "Format discriminator for automation. The fixed value identifies the document as an AI SBOM."
+        },
+        "sbomAuthor": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sbomVersion": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sbomDataFormatName": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sbomDataFormatVersion": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sbomAuthorSignature": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "algorithm",
+            "value"
+          ],
+          "properties": {
+            "algorithm": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "value": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "certificateUrl": {
+              "$ref": "#/$defs/uri"
+            }
+          }
+        },
+        "sbomToolName": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sbomToolVersion": {
+          "$ref": "#/$defs/unknownableString"
+        },
+        "sbomGenerationContext": {
+          "type": "string",
+          "enum": [
+            "before-build",
+            "build",
+            "after-build",
+            "source-analysis",
+            "binary-analysis",
+            "runtime-analysis",
+            "manual",
+            "unknown"
+          ]
+        },
+        "sbomTimestamp": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "sbomDependencyRelationships": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dependencyRelationship"
+          }
+        }
+      }
+    },
+    "system": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "systemName",
+        "systemComponents",
+        "systemProducer"
+      ],
+      "properties": {
+        "systemName": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "systemComponents": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "type"
+            ],
+            "properties": {
+              "name": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ai-model",
+                  "database",
+                  "software",
+                  "api",
+                  "agent",
+                  "service",
+                  "other"
+                ]
+              },
+              "version": {
+                "$ref": "#/$defs/unknownableString"
+              },
+              "supplier": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            }
+          }
+        },
+        "systemProducer": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "systemVersion": {
+          "$ref": "#/$defs/unknownableString"
+        },
+        "systemTimestamp": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "systemDataFlow": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "source",
+              "destination",
+              "description"
+            ],
+            "properties": {
+              "source": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "destination": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "description": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "protocol": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "externalService": {
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "systemDataUsage": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "systemInputOutputProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "inputModalities",
+            "outputModalities",
+            "inputPreprocessing"
+          ],
+          "properties": {
+            "inputModalities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "outputModalities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "inputPreprocessing": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "decisionImpactDocumentationUrl": {
+              "$ref": "#/$defs/uri"
+            }
+          }
+        },
+        "intendedApplicationArea": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "modelName",
+        "modelIdentifiers",
+        "modelProducers"
+      ],
+      "properties": {
+        "modelName": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "modelIdentifiers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "modelVersion": {
+          "$ref": "#/$defs/unknownableString"
+        },
+        "modelTimestamp": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "modelProducers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "modelDescription": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "capabilities"
+          ],
+          "properties": {
+            "capabilities": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "knownLimitations": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "lineage": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "dependencies": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            }
+          }
+        },
+        "modelHashValue": {
+          "$ref": "#/$defs/hashValue"
+        },
+        "modelHashAlgorithm": {
+          "$ref": "#/$defs/hashAlgorithm"
+        },
+        "modelProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "modelFamily"
+          ],
+          "properties": {
+            "modelFamily": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "architecture": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "parameterCount": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "const": "unknown"
+                }
+              ]
+            },
+            "hyperparameters": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "modelInputOutputProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "inputModalities",
+            "outputModalities"
+          ],
+          "properties": {
+            "inputModalities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "outputModalities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "contextLength": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "const": "unknown"
+                }
+              ]
+            },
+            "inputPreprocessing": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        },
+        "modelTrainingProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "learningType"
+          ],
+          "properties": {
+            "learningType": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "trainingStages": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "documentationUrl": {
+              "$ref": "#/$defs/uri"
+            }
+          }
+        },
+        "modelLicense": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "url": {
+              "$ref": "#/$defs/uri"
+            },
+            "openness": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "openWeights"
+              ],
+              "properties": {
+                "openWeights": {
+                  "type": "boolean"
+                },
+                "openArchitecture": {
+                  "type": "boolean"
+                },
+                "openData": {
+                  "type": "boolean"
+                },
+                "openTraining": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "modelExternalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/externalReference"
+          }
+        }
+      }
+    },
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "datasetName",
+        "datasetDescription"
+      ],
+      "properties": {
+        "datasetName": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "datasetDescription": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "datasetContent": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "domain"
+          ],
+          "properties": {
+            "domain": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "format": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "dataModalities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            }
+          }
+        },
+        "datasetIdentifiers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "datasetHash": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "algorithm",
+            "value"
+          ],
+          "properties": {
+            "algorithm": {
+              "$ref": "#/$defs/hashAlgorithm"
+            },
+            "value": {
+              "$ref": "#/$defs/hashValue"
+            }
+          }
+        },
+        "datasetProvenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "origin"
+          ],
+          "properties": {
+            "origin": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "collectionMethods": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "processingSteps": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            },
+            "creator": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "syntheticDataMethods": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        },
+        "datasetStatisticalProperties": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "datasetSensitivity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "description"
+          ],
+          "properties": {
+            "containsPersonalData": {
+              "type": "boolean"
+            },
+            "containsSensitiveData": {
+              "type": "boolean"
+            },
+            "containsCopyrightProtectedData": {
+              "type": "boolean"
+            },
+            "containsNationalSecurityData": {
+              "type": "boolean"
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        },
+        "datasetDependencyRelationships": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dependencyRelationship"
+          }
+        },
+        "datasetLicense": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "$ref": "#/$defs/nonEmptyString"
+            },
+            "url": {
+              "$ref": "#/$defs/uri"
+            }
+          }
+        }
+      }
+    },
+    "infrastructure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "infrastructureSoftware"
+      ],
+      "properties": {
+        "infrastructureSoftware": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "type"
+            ],
+            "properties": {
+              "name": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "firmware",
+                  "package-manager",
+                  "library",
+                  "framework",
+                  "runtime",
+                  "tool",
+                  "service",
+                  "other"
+                ]
+              },
+              "version": {
+                "$ref": "#/$defs/unknownableString"
+              },
+              "supplier": {
+                "$ref": "#/$defs/nonEmptyString"
+              }
+            }
+          }
+        },
+        "infrastructureHardware": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "hbomUrl"
+          ],
+          "properties": {
+            "hbomUrl": {
+              "$ref": "#/$defs/uri"
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        }
+      }
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "securityControls": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "category"
+            ],
+            "properties": {
+              "name": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "category": {
+                "type": "string",
+                "enum": [
+                  "general-cybersecurity",
+                  "ai-specific",
+                  "physical",
+                  "administrative",
+                  "technical"
+                ]
+              },
+              "description": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "referenceUrl": {
+                "$ref": "#/$defs/uri"
+              }
+            }
+          }
+        },
+        "securityCompliance": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "certified",
+                  "self-attested",
+                  "in-progress",
+                  "not-assessed",
+                  "not-applicable"
+                ]
+              },
+              "referenceUrl": {
+                "$ref": "#/$defs/uri"
+              }
+            }
+          }
+        },
+        "cybersecurityPolicyInformation": {
+          "$ref": "#/$defs/uri"
+        },
+        "vulnerabilityReferencing": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/externalReference"
+          }
+        }
+      }
+    },
+    "kpis": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "securityMetrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "value": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/$defs/nonEmptyString"
+                  }
+                ]
+              },
+              "unit": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "measurementTimestamp": {
+                "$ref": "#/$defs/timestamp"
+              }
+            }
+          }
+        },
+        "operationalPerformanceKpis": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "value": {
+                "oneOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/$defs/nonEmptyString"
+                  }
+                ]
+              },
+              "unit": {
+                "$ref": "#/$defs/nonEmptyString"
+              },
+              "measurementTimestamp": {
+                "$ref": "#/$defs/timestamp"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/validator.go
+++ b/validator.go
@@ -14,6 +14,7 @@ import (
 const (
 	SBOM_CYCLONEDX = "CycloneDX"
 	SBOM_SPDX      = "SPDX"
+	SBOM_AI        = "AI-SBOM"
 )
 
 const cyclonedxSchemaBaseURL = "http://cyclonedx.org/schema/"
@@ -75,9 +76,9 @@ type ValidationResult struct {
 	DetectedFormat   string   `json:"detectedFormat,omitempty"`
 }
 
-// Embed all JSON schema files from the schemas/cyclonedx directory
+// Embed all JSON schema files from the schemas directory.
 //
-//go:embed schemas/cyclonedx/*.json schemas/spdx/*.json
+//go:embed schemas/cyclonedx/*.json schemas/spdx/*.json schemas/ai-bom/*.json
 var schemaFS embed.FS
 
 // ValidateSBOMData is the main function to validate SBOM data using this library.
@@ -85,7 +86,7 @@ var schemaFS embed.FS
 // This function serves as a wrapper around multiple internal functions, making it the
 // recommended entry point for validating SBOMs. It performs the following steps:
 // 1. Detects whether the SBOM is in JSON format.
-// 2. Determines the SBOM type (CycloneDX, SPDX, etc.).
+// 2. Determines the SBOM type (CycloneDX, SPDX, AI-SBOM, etc.).
 // 3. Extracts the schema version from the SBOM data.
 // 4. Loads the corresponding schema for validation.
 // 5. Validates the SBOM against the schema and returns the validation result.
@@ -101,13 +102,13 @@ var schemaFS embed.FS
 // Errors:
 //   - Returns an error if the SBOM format is not JSON.
 //   - Returns an error if SBOM type detection fails.
-//   - Returns an error if the SBOM type is not CycloneDX (currently the only supported format).
+//   - Returns an error if the SBOM type is unsupported.
 //   - Returns an error if extracting the SBOM version fails.
 //   - Returns an error if loading the schema fails.
 //
 // Note:
 //   - This function abstracts multiple lower-level functions, such as `DetectSBOMType`,
-//     `ExtractVersion`, `LoadSchema`, and `ValidateSBOM`. Instead of calling those
+//     `extractSBOMVersion`, `loadSBOMSchema`, and `validateSBOM`. Instead of calling those
 //     individually, use `ValidateSBOMData` for a streamlined validation process.
 //
 // Example usage:
@@ -177,7 +178,7 @@ func ValidateSBOMData(sbomContent []byte) (*ValidationResult, error) {
 //
 // Returns:
 //   - A string representing the detected SBOM format.
-//   - An error if the JSON is invalid or the "bomFormat" field is missing.
+//   - An error if the JSON is invalid or no supported SBOM discriminator is found.
 //
 // Example:
 //
@@ -198,6 +199,23 @@ func detectSBOMType(jsonData string) (string, error) {
 	if ok {
 		debugLogger.Printf("%s SBOM type detected", cyclonedxFormat)
 		return cyclonedxFormat, nil
+	}
+
+	if metadata, ok := obj["metadata"].(map[string]interface{}); ok {
+		if bomFormat, ok := metadata["bomFormat"].(string); ok && bomFormat == SBOM_AI {
+			debugLogger.Printf("%s SBOM type detected", bomFormat)
+			return bomFormat, nil
+		}
+	}
+
+	if schemaVersion, ok := obj["schemaVersion"].(string); ok && schemaVersion != "" {
+		_, hasMetadata := obj["metadata"]
+		_, hasSystem := obj["system"]
+		_, hasModels := obj["models"]
+		if hasMetadata && hasSystem && hasModels {
+			debugLogger.Printf("%s SBOM type detected", SBOM_AI)
+			return SBOM_AI, nil
+		}
 	}
 
 	spdxVersion, ok := obj["spdxVersion"].(string)
@@ -284,7 +302,7 @@ func addOfflineFallbackSchemas(loader *gojsonschema.SchemaLoader) error {
 // extractSBOMVersion extracts the "version" field from an SBOM JSON string.
 //
 // This function parses the provided JSON data and retrieves the version field
-// based on the specified SBOM type. Currently, it supports CycloneDX SBOMs.
+// based on the specified SBOM type.
 //
 // Parameters:
 //   - jsonData: A string containing the SBOM JSON data.
@@ -325,6 +343,14 @@ func extractSBOMVersion(jsonData string, sbomType string) (string, error) {
 
 		debugLogger.Println("SPDX version is set to:", version)
 		return version, nil
+	} else if sbomType == SBOM_AI {
+		version, ok := obj["schemaVersion"].(string)
+		if !ok {
+			return "", fmt.Errorf(`"schemaVersion" field missing or not a string`)
+		}
+
+		debugLogger.Println("AI-SBOM version is set to:", version)
+		return version, nil
 	}
 
 	return "", fmt.Errorf("unknown SBOM Format")
@@ -337,8 +363,7 @@ func extractSBOMVersion(jsonData string, sbomType string) (string, error) {
 //
 // Parameters:
 //   - version: The version of the SBOM schema (e.g., "1.4").
-//   - schemaDir: The directory where schema files are stored.
-//   - sbomType: The type of SBOM (currently supports "CycloneDX").
+//   - sbomType: The type of SBOM.
 //
 // Returns:
 //   - A string containing the JSON schema content.
@@ -356,6 +381,8 @@ func loadSBOMSchema(version string, sbomType string) (string, error) {
 
 	if sbomType == SBOM_CYCLONEDX {
 		schemaFile = fmt.Sprintf("schemas/cyclonedx/bom-%s.schema.json", version)
+	} else if sbomType == SBOM_AI {
+		schemaFile = fmt.Sprintf("schemas/ai-bom/ai-sbom-%s.schema.json", version)
 	} else if strings.Contains(sbomType, SBOM_SPDX) {
 		spdxVersion, err := getSPDXVersion(version)
 		if err != nil {

--- a/validator_test.go
+++ b/validator_test.go
@@ -26,6 +26,18 @@ func TestDetectSBOMType(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name:      "Valid AI-SBOM with metadata bomFormat",
+			jsonData:  `{"schemaVersion": "1.0.0", "metadata": {"bomFormat": "AI-SBOM"}, "system": {}, "models": []}`,
+			want:      "AI-SBOM",
+			expectErr: false,
+		},
+		{
+			name:      "AI-SBOM shape without metadata bomFormat",
+			jsonData:  `{"schemaVersion": "1.0.0", "metadata": {}, "system": {}, "models": []}`,
+			want:      "AI-SBOM",
+			expectErr: false,
+		},
+		{
 			name:      "Missing bomFormat field",
 			jsonData:  `{"specVersion": "1.4"}`,
 			expectErr: true,
@@ -86,6 +98,12 @@ func TestLoadSchema(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "Valid AI-SBOM Schema",
+			version:  "1.0.0",
+			sbomType: SBOM_AI,
+			wantErr:  false,
+		},
+		{
 			name:     "Schema File Not Found",
 			version:  "2.0", // This version does not exist in embedded schemas
 			sbomType: SBOM_CYCLONEDX,
@@ -142,6 +160,13 @@ func TestExtractVersion(t *testing.T) {
 			sbomType:  "SPDX",
 			expectErr: false,
 			wantValue: "SPDX-2.3",
+		},
+		{
+			name:      "Valid AI-SBOM",
+			jsonData:  `{"schemaVersion": "1.0.0"}`,
+			sbomType:  SBOM_AI,
+			expectErr: false,
+			wantValue: "1.0.0",
 		},
 		{
 			name:      "Missing specVersion field",
@@ -297,6 +322,70 @@ func TestValidateSBOMDataOfflineCycloneDX(t *testing.T) {
 
 			if !result.IsValid {
 				t.Fatalf("expected %s to be valid, got errors: %v", tt.path, result.ValidationErrors)
+			}
+		})
+	}
+}
+
+func TestValidateSBOMDataOfflineAISBOM(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantValid bool
+	}{
+		{
+			name:      "Customer Support AI-SBOM",
+			path:      "sample-sboms/customer-support-ai-sbom.json",
+			wantValid: true,
+		},
+		{
+			name:      "Medical Triage AI-SBOM",
+			path:      "sample-sboms/medical-triage-ai-sbom.json",
+			wantValid: true,
+		},
+		{
+			name:      "Missing Required Metadata",
+			path:      "sample-sboms/missing-required-metadata.json",
+			wantValid: false,
+		},
+		{
+			name:      "Bad Types And Enums",
+			path:      "sample-sboms/bad-types-and-enums-ai-sbom.json",
+			wantValid: false,
+		},
+		{
+			name:      "Unknown Extra Properties",
+			path:      "sample-sboms/unknown-extra-properties-ai-sbom.json",
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sbomData, err := os.ReadFile(tt.path)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", tt.path, err)
+			}
+
+			result, err := ValidateSBOMData(sbomData)
+			if err != nil {
+				t.Fatalf("expected AI-SBOM validation to run for %s: %v", tt.path, err)
+			}
+
+			if result.SBOMType != SBOM_AI {
+				t.Fatalf("expected SBOM type %q, got %q", SBOM_AI, result.SBOMType)
+			}
+
+			if result.SBOMVersion != "1.0.0" {
+				t.Fatalf("expected SBOM version 1.0.0, got %q", result.SBOMVersion)
+			}
+
+			if result.IsValid != tt.wantValid {
+				t.Fatalf("expected validity %v for %s, got %v with errors: %v", tt.wantValid, tt.path, result.IsValid, result.ValidationErrors)
+			}
+
+			if !tt.wantValid && len(result.ValidationErrors) == 0 {
+				t.Fatalf("expected validation errors for invalid AI-SBOM %s", tt.path)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds support for validating AI-SBOM documents using the AI BOM 1.0.0 schema.

## Changes

- Added embedded AI-SBOM 1.0.0 schema under `schemas/ai-bom/`
- Added AI-SBOM type detection using `metadata.bomFormat` and AI-SBOM document shape
- Added AI-SBOM version extraction from top-level `schemaVersion`
- Added schema loading support for AI-SBOM files
- Added valid AI-SBOM examples:
  - `customer-support-ai-sbom.json`
  - `medical-triage-ai-sbom.json`
- Added invalid AI-SBOM examples:
  - `missing-required-metadata.json`
  - `bad-types-and-enums-ai-sbom.json`
  - `unknown-extra-properties-ai-sbom.json`
- Updated tests for detection, schema loading, version extraction, and valid/invalid AI-SBOM validation
- Updated README supported formats and example output
- Confirmed existing CycloneDX and SPDX validation behavior continues to pass

## Testing

```sh
GOCACHE=/private/tmp/sbom-validator-go-cache go test ./...